### PR TITLE
handel navigation and app router

### DIFF
--- a/lib/core/common/screens/no_route_screen.dart
+++ b/lib/core/common/screens/no_route_screen.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class NoRouteScreen extends StatelessWidget {
+  const NoRouteScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Text('No route defined'),
+      ),
+    );
+  }
+}

--- a/lib/core/extentions/navigation_context.dart
+++ b/lib/core/extentions/navigation_context.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+extension NavigationContext on BuildContext {
+  void pushNamed(String routeName, {Object? arguments}) =>
+      Navigator.pushNamed(this, routeName, arguments: arguments);
+  void pushReplacementNamed(String routeName, {Object? arguments}) =>
+      Navigator.pushReplacementNamed(this, routeName, arguments: arguments);
+  void pushNamedAndRemoveUntil(String routeName) =>
+      Navigator.pushNamedAndRemoveUntil(this, routeName, (route) => false);
+  void pop() => Navigator.pop(this);
+}

--- a/lib/core/routes/app_router.dart
+++ b/lib/core/routes/app_router.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:my_store/core/common/screens/no_route_screen.dart';
+import 'package:my_store/core/routes/base_material_page_route.dart';
+import 'package:my_store/core/routes/routes.dart';
+import 'package:my_store/home_screen.dart';
+
+class AppRouter {
+  static Route<void> getRoute(RouteSettings settings) {
+    final argument = settings.arguments;
+    switch (settings.name) {
+      case Routes.home:
+        return BaseRoute(page: const HomeScreen());
+      default:
+        return BaseRoute(page: const NoRouteScreen());
+    }
+  }
+}

--- a/lib/core/routes/base_material_page_route.dart
+++ b/lib/core/routes/base_material_page_route.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+class BaseRoute extends PageRouteBuilder<dynamic> {
+  BaseRoute({required this.page})
+      : super(
+          pageBuilder: (
+            BuildContext context,
+            Animation<double> animation,
+            Animation<double> secondaryAnimation,
+          ) =>
+              Stack(children: [page]),
+          transitionsBuilder: (
+            BuildContext context,
+            Animation<double> animation,
+            Animation<double> secondaryAnimation,
+            Widget widget,
+          ) {
+            const begin = 0.0;
+            const end = 1.0;
+            final tween = Tween(begin: begin, end: end);
+            final caurvesanimation = CurvedAnimation(
+              parent: animation,
+              curve: Curves.linearToEaseOut,
+            );
+
+            return ScaleTransition(
+              scale: tween.animate(caurvesanimation),
+              child: widget,
+            );
+          },
+        );
+  Widget page;
+}

--- a/lib/core/routes/routes.dart
+++ b/lib/core/routes/routes.dart
@@ -1,0 +1,4 @@
+class Routes {
+  static const String home = 'Home_Screen';
+  static const String login = 'login_Screen';
+}

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Home'),
+      ),
+      body: const Center(
+        child: Text('Home Screen'),
+      ),
+    );
+  }
+}

--- a/lib/my_store.dart
+++ b/lib/my_store.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:my_store/core/app/network_connection_checker.dart';
 import 'package:my_store/core/common/screens/no_network_connection.dart';
+import 'package:my_store/core/routes/app_router.dart';
+import 'package:my_store/core/routes/routes.dart';
 
 class MyStore extends StatelessWidget {
   const MyStore({super.key});
@@ -17,11 +19,8 @@ class MyStore extends StatelessWidget {
                   colorScheme: ColorScheme.fromSeed(seedColor: Colors.white),
                   useMaterial3: true,
                 ),
-                home: const Scaffold(
-                  body: Center(
-                    child: Text('My Store'),
-                  ),
-                ),
+                onGenerateRoute: AppRouter.getRoute,
+                initialRoute: Routes.home,
               )
             : MaterialApp(
                 debugShowCheckedModeBanner: false,


### PR DESCRIPTION
screens:
- create no route screen
- create simple empty home screen

Routes:
- create Routes class which has all route names
- create an app router to generate routes in material app
- create base_material_page_route with animation 

Extensions:
- create navigation ex on context
